### PR TITLE
Gracefully handle when an expected node cannot be diffed

### DIFF
--- a/src/element-matcher.test.tsx
+++ b/src/element-matcher.test.tsx
@@ -10,8 +10,13 @@ import { ElementMatcher, ExpectElement } from "./element-matcher";
 const MyComponent: React.FC = () => (
     <div>
         My components body.
+        <MyChildComponent />
     </div>
 );
+
+const MyChildComponent: React.FC = () => {
+    throw new Error("Simulating a child component that cannot be rendered within the test suite");
+};
 
 @TestFixture("ElementMatcher")
 export class ElementMatcherTests {
@@ -41,6 +46,15 @@ export class ElementMatcherTests {
 
         const elementMatcher = new ElementMatcher<ShallowWrapper>(wrapper);
 
-        Expect(() => elementMatcher.toMatchElement(<div>My components body.</div>)).not.toThrow();
+        Expect(() => elementMatcher.toMatchElement(<div>My components body.<MyChildComponent /></div>)).not.toThrow();
+    }
+
+    @Test("should throw match error if components cannot be rendered by the call to shallow")
+    public shouldThrowWithUnrenderableComponent() {
+
+        const wrapper = shallow(<MyComponent />);
+
+        Expect(() => ExpectElement(wrapper.find(MyChildComponent))
+            .toMatchElement(<MyChildComponent>something</MyChildComponent>)).toThrowError(MatchError, "Expected elements to match");
     }
 }

--- a/src/element-matcher.ts
+++ b/src/element-matcher.ts
@@ -9,8 +9,17 @@ export class ElementMatcher<T extends CommonWrapper> extends Matcher<T> {
 
         if (!this.actualValue.matchesElement(node)) {
 
-            const expected = shallow(node).debug();
-            const actual = this.actualValue.debug();
+            let expected;
+            let actual;
+            try {
+                expected = shallow(node).debug();
+                actual = this.actualValue.debug();
+            } catch {
+                // If the calls to shallow or debug fail then we still want the MatchError to be thrown
+                // so perform the diff over the react elements directly instead as a compromise
+                expected = node;
+                actual = this.actualValue.getElement();
+            }
 
             throw new MatchError(
                 "Expected elements to match",


### PR DESCRIPTION
This ensures that you will still get a MatchError even if the expected node cannot be rendered with `shallow` or `debug`